### PR TITLE
Add displaying the build version.

### DIFF
--- a/BDCSCli.cabal
+++ b/BDCSCli.cabal
@@ -40,9 +40,12 @@ library
 executable bdcs-cli
   main-is:              bdcs-cli.hs
   hs-source-dirs:       tools
+                        dist/build/autogen
   build-depends:        base,
+                        gitrev,
                         wreq,
                         BDCSCli
+  other-modules:        Paths_BDCSCli
   default-language:     Haskell2010
 
 test-suite spec

--- a/tools/bdcs-cli.hs
+++ b/tools/bdcs-cli.hs
@@ -15,10 +15,14 @@
 -- You should have received a copy of the GNU General Public License
 -- along with bdcs-cli.  If not, see <http://www.gnu.org/licenses/>.
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 import Control.Monad (when)
+import Data.Version (showVersion)
+import Development.GitRev
 import Network.Wreq.Session as S
 
+import Paths_BDCSCli (version)
 import BDCSCli.Cmdline(CliOptions(..), parseArgs)
 import BDCSCli.Commands(parseCommand)
 
@@ -32,6 +36,12 @@ main = S.withSession $ \sess -> do
     r <- parseArgs
     let opts = fst r
     let commands = snd r
+    when (optShowVersion opts) $ do
+        let git_version = $(gitDescribe)
+        if git_version == "UNKNOWN" then
+            putStrLn ("bdcs-cli v" ++ showVersion version)
+        else
+            putStrLn ("bdcs-cli " ++ git_version)
     when (optVerbose opts) $ do
         print opts
         print commands


### PR DESCRIPTION
If built from git, it will use the 'git describe' format, including the
most recent tag and short hash of the commit it was built from. If no
git version is available it will fall back to the version in the cabal
file.