### PR TITLE
Use a ReaderT to pass the Wreq session and cmdline options around.

### DIFF
--- a/BDCSCli.cabal
+++ b/BDCSCli.cabal
@@ -18,6 +18,7 @@ cabal-version:          >=1.10
 library
   exposed-modules:      BDCSCli.API.V0
                         BDCSCli.Cmdline
+                        BDCSCli.CommandCtx
                         BDCSCli.Commands
                         BDCSCli.URL
                         BDCSCli.Utilities
@@ -29,6 +30,7 @@ library
                         directory,
                         lens,
                         lens-aeson,
+                        mtl,
                         process,
                         split,
                         temporary,
@@ -45,6 +47,7 @@ executable bdcs-cli
                         dist/build/autogen
   build-depends:        base,
                         gitrev,
+                        mtl,
                         wreq,
                         BDCSCli
   other-modules:        Paths_BDCSCli

--- a/BDCSCli/CommandCtx.hs
+++ b/BDCSCli/CommandCtx.hs
@@ -1,0 +1,29 @@
+-- Copyright (C) 2017 Red Hat, Inc.
+--
+-- This file is part of bdcs-cli.
+--
+-- bdcs-cli is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- bdcs-cli is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with bdcs-cli.  If not, see <http://www.gnu.org/licenses/>.
+
+module BDCSCli.CommandCtx(CommandCtx(..))
+  where
+
+import Network.Wreq.Session as S
+
+import BDCSCli.Cmdline(CliOptions(..))
+
+-- | Session and cmdline options for use by the application
+data CommandCtx = CommandCtx {
+    ctxSession :: Session,
+    ctxOptions :: CliOptions
+}

--- a/tools/bdcs-cli.hs
+++ b/tools/bdcs-cli.hs
@@ -18,18 +18,19 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 import Control.Monad (when)
+import Control.Monad.Reader(runReaderT)
 import Data.Version (showVersion)
 import Development.GitRev
 import Network.Wreq.Session as S
 
 import Paths_BDCSCli (version)
 import BDCSCli.Cmdline(CliOptions(..), parseArgs)
+import BDCSCli.CommandCtx(CommandCtx(..))
 import BDCSCli.Commands(parseCommand)
 
 -- | Print the API URL selection (or the default)
 printUrl :: CliOptions -> IO ()
 printUrl CliOptions{..} = putStrLn optUrl
-
 
 main :: IO ()
 main = S.withSession $ \sess -> do
@@ -46,4 +47,6 @@ main = S.withSession $ \sess -> do
         print opts
         print commands
         printUrl opts
-    parseCommand sess opts commands
+
+    let ctx = CommandCtx { ctxSession = sess, ctxOptions = opts }
+    runReaderT (parseCommand commands) ctx


### PR DESCRIPTION
The goal here was to make things cleaner and more Haskell-like.
Given the added complexity and additional boilerplate (liftIO
everywhere) I'm not really sure it was worth it.