### PR TITLE
Add tests for bdcs-cli binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,16 @@ script:
   - cabal build
   - cabal test --show-details=always
 
+  # tests for bdcs-cli binary
+  - ./tests/test_binary.sh
+
+  # collect binary coverage
+  - mkdir ./dist/hpc/vanilla/tix/bdcs-cli/
+  - mv bdcs-cli.tix ./dist/hpc/vanilla/tix/bdcs-cli/
+
 after_success:
   - cabal install hpc-coveralls
-  - ~/.cabal/bin/hpc-coveralls --display-report spec
+  - ~/.cabal/bin/hpc-coveralls --display-report spec bdcs-cli
 
 notifications:
   email:

--- a/tests/test_binary.sh
+++ b/tests/test_binary.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -x
+
+# Note: execute this file from the project root directory
+
+bdcscli="./dist/build/bdcs-cli/bdcs-cli"
+
+# When called without parameters returns Unknown Command
+if [[ `$bdcscli` != "Unknown Command" ]]; then
+    exit 1
+fi
+
+# --help option is not recognized
+if [[ `$bdcscli --help 2>&1 | head -n 1` != "bdcs-cli: user error (unrecognized option \`--help'" ]]; then
+    exit 1
+fi
+
+# -? returns version only
+if [[ `$bdcscli -? | cut -f1 -d' '` != "bdcs-cli" ]]; then
+    exit 1
+fi


### PR DESCRIPTION
The last test will fail b/c `bdcs-cli -?` produces
```
bdcs-cli 55553e7
Unknown Command   <--- we don't need this
```