### PR TITLE
Exit after showing program version

### DIFF
--- a/BDCSCli/Commands.hs
+++ b/BDCSCli/Commands.hs
@@ -213,6 +213,7 @@ projectsCommand _    _     = putStrLn "ERROR: Missing projects command"
 
 -- Execute a command and print the results
 parseCommand :: CommandCtx -> [String] -> IO ()
+parseCommand (CommandCtx _ CliOptions {optShowVersion = True}) _ = return ()
 parseCommand ctx ("compose":xs)          = composeCommand ctx xs
 parseCommand ctx ("recipes":"freeze":xs) = recipesFreeze ctx xs
 parseCommand ctx ("recipes":xs)          = recipesCommand ctx xs


### PR DESCRIPTION
@bcl this is one possible solution. I can't think of a useful scenario where we want to show both the version and perform another action.