### PR TITLE
Depsolve tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 cabal.sandbox.config
 dist
 .*.swp
+*.tix
+*.sql
+*.db
+export
+import

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ dist
 *.tix
 *.sql
 *.db
+*.pyc
 export
 import

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 dist: trusty
 sudo: required
 language: c
+services:
+  - docker
 
 cache:
   directories:
@@ -8,8 +10,9 @@ cache:
     - ~/.cabal
 
 before_install:
-  - pip install s3cmd
-  - wget https://haskell.org/platform/download/8.0.2/haskell-platform-8.0.2-unknown-posix--minimal-x86_64.tar.gz
+  - sudo docker pull welder/bdcs-api-rs:latest
+  - pip install s3cmd toml parameterized
+  - wget --progress=dot:giga https://haskell.org/platform/download/8.0.2/haskell-platform-8.0.2-unknown-posix--minimal-x86_64.tar.gz
   - tar -xzvf ./haskell-platform-8.0.2-unknown-posix--minimal-x86_64.tar.gz
   - sudo ./install-haskell-platform.sh
   - travis_retry cabal update && cabal install hlint hpc-coveralls
@@ -23,6 +26,8 @@ script:
 
   # tests for bdcs-cli binary
   - ./tests/test_binary.sh
+  # depsolve integration tests
+  - ./tests/test_depsolve.sh
 
   # collect binary coverage
   - mkdir ./dist/hpc/vanilla/tix/bdcs-cli/

--- a/examples/recipes/atlas.toml
+++ b/examples/recipes/atlas.toml
@@ -1,0 +1,10 @@
+name = "atlas"
+description = "Automatically Tuned Linear Algebra Software"
+
+[[modules]]
+name = "atlas"
+version = "3.10.*"
+
+[[modules]]
+name = "numpy"
+version = "1.7.*"

--- a/examples/recipes/development.toml
+++ b/examples/recipes/development.toml
@@ -1,0 +1,82 @@
+name = "development"
+description = "A general purpose development image"
+
+[[packages]]
+name = "cmake"
+version = "*"
+
+[[packages]]
+name = "curl"
+version = "*"
+
+[[packages]]
+name = "file"
+version = "*"
+
+[[packages]]
+name = "gcc"
+version = "*"
+
+[[packages]]
+name = "gcc-c++"
+version = "*"
+
+[[packages]]
+name = "gdb"
+version = "*"
+
+[[packages]]
+name = "git"
+version = "*"
+
+[[packages]]
+name = "glibc-devel"
+version = "*"
+
+[[packages]]
+name = "gnupg2"
+version = "*"
+
+[[packages]]
+name = "libcurl-devel"
+version = "*"
+
+[[packages]]
+name = "make"
+version = "*"
+
+[[packages]]
+name = "openssl-devel"
+version = "*"
+
+[[packages]]
+name = "openssl-devel"
+version = "*"
+
+[[packages]]
+name = "sqlite"
+version = "*"
+
+[[packages]]
+name = "sqlite-devel"
+version = "*"
+
+[[packages]]
+name = "sudo"
+version = "*"
+
+[[packages]]
+name = "tar"
+version = "*"
+
+[[packages]]
+name = "xz"
+version = "*"
+
+[[packages]]
+name = "xz-devel"
+version = "*"
+
+[[packages]]
+name = "zlib-devel"
+version = "*"

--- a/examples/recipes/glusterfs.toml
+++ b/examples/recipes/glusterfs.toml
@@ -1,0 +1,14 @@
+name = "glusterfs"
+description = "An example GlusterFS server with samba"
+
+[[modules]]
+name = "glusterfs"
+version = "3.7.*"
+
+[[modules]]
+name = "glusterfs-cli"
+version = "3.7.*"
+
+[[packages]]
+name = "samba"
+version = "4.2.*"

--- a/examples/recipes/http-server.toml
+++ b/examples/recipes/http-server.toml
@@ -1,0 +1,34 @@
+name = "http-server"
+description = "An example http server with PHP and MySQL support."
+
+[[modules]]
+name = "httpd"
+version = "2.4.*"
+
+[[modules]]
+name = "mod_auth_kerb"
+version = "5.4"
+
+[[modules]]
+name = "mod_ssl"
+version = "2.4.*"
+
+[[modules]]
+name = "php"
+version = "5.4.*"
+
+[[modules]]
+name = "php-mysql"
+version = "5.4.*"
+
+[[packages]]
+name = "tmux"
+version = "2.2"
+
+[[packages]]
+name = "openssh-server"
+version = "6.6.*"
+
+[[packages]]
+name = "rsync"
+version = "3.0.*"

--- a/examples/recipes/jboss.toml
+++ b/examples/recipes/jboss.toml
@@ -1,0 +1,14 @@
+name = "jboss"
+description = "An example jboss server"
+
+[[modules]]
+name = "jboss-servlet-3.0-api"
+version = "1.0.*"
+
+[[modules]]
+name = "jboss-interceptors-1.1-api"
+version = "1.0.*"
+
+[[modules]]
+name = "java-1.8.0-openjdk"
+version = "1.8.0.*"

--- a/examples/recipes/kubernetes.toml
+++ b/examples/recipes/kubernetes.toml
@@ -1,0 +1,26 @@
+name = "kubernetes"
+description = "An example kubernetes master"
+
+[[modules]]
+name = "kubernetes"
+version = "1.2.*"
+
+[[modules]]
+name = "docker"
+version = "1.10.*"
+
+[[modules]]
+name = "docker-lvm-plugin"
+version = "1.10.*"
+
+[[modules]]
+name = "etcd"
+version = "2.3.*"
+
+[[modules]]
+name = "flannel"
+version = "0.5.*"
+
+[[packages]]
+name = "oci-systemd-hook"
+version = "0.1.*"

--- a/tests/test_depsolve.py
+++ b/tests/test_depsolve.py
@@ -1,0 +1,73 @@
+#pylint: disable=missing-docstring,import-error,too-many-public-methods
+
+import os
+import unittest
+from subprocess import check_output, CalledProcessError
+
+import toml
+
+try:
+    from parameterized import parameterized
+except ImportError:
+    # on Fedora 25 (Docker)
+    from nose_parameterized import parameterized
+
+
+_TEST_DIR = os.path.dirname(__file__)
+
+_RECIPE_DIR = os.path.join(_TEST_DIR, '..', 'examples', 'recipes')
+_RECIPE_DIR = os.path.abspath(_RECIPE_DIR)
+
+_DEPSOLVE = os.path.join(_TEST_DIR, '..', 'dist', 'build', 'bdcs-cli', 'bdcs-cli')
+_DEPSOLVE = [os.path.abspath(_DEPSOLVE), 'recipes', 'depsolve']
+
+_RECIPES = []
+for _dirpath, _dirnames, filenames in os.walk(_RECIPE_DIR):
+    for _recipe in filenames:
+        if _recipe.endswith('.toml'):
+            _RECIPES.append(_recipe)
+
+
+def read_toml(fname):
+    return toml.loads(open(os.path.join(_RECIPE_DIR, fname), 'r').read())
+
+def exec_depsolve(recipe_name):
+    # will raise CalledProcessError exception if depsolve
+    # exit status is != 0
+    return check_output(_DEPSOLVE + [recipe_name])
+
+
+class DepsolveTestCase(unittest.TestCase):
+    @parameterized.expand(_RECIPES)
+    def test_depsolve(self, recipe_file):
+        recipe = read_toml(recipe_file)
+
+        expected_packages = []
+        for key in ['packages', 'modules']:
+            if key in recipe:
+                for pkg in recipe[key]:
+                    expected_packages.append(pkg['name'])
+
+        # step 1: can we resolve all the dependencies
+        try:
+            recipe_name = recipe_file.replace('.toml', '')
+            depsolve_output = exec_depsolve(recipe_name)
+        except CalledProcessError as err:
+            self.assertEqual('', err.output)
+            self.fail('depsolve failed!')
+
+        # KNOWN ISSUE, WONT FIX, SKIP
+        # https://trello.com/c/0D3pbzaA/291-bug-depsolve-is-killed-when-mddb-contains-updates
+        # TODO: remove this skip once we switch over to the bdcs depsolving code
+        if recipe_name == 'kubernetes':
+            self.skipTest('known issue with updates for kubernetes')
+
+        # step 2: is what the user wanted still in the list
+        for pkg in expected_packages:
+            self.assertIn(pkg, depsolve_output)
+
+        # step 3: sanity test specific functionality
+        # this is now https://github.com/weldr/bdcs-cli/pull/16
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_depsolve.sh
+++ b/tests/test_depsolve.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -x
+
+# Note: execute this file from the project root directory
+
+BDCS_CLI="./dist/build/bdcs-cli/bdcs-cli"
+
+METADATA_DB="metadata.db"
+[ -f "$METADATA_DB" ] || curl https://s3.amazonaws.com/weldr/metadata.db > "$METADATA_DB"
+
+# start the backend API which provides depsolving
+# later this will be replaces with the depsolver from bdcs library
+sudo docker run -d --rm --name api -p 4000:4000 -v `pwd`:/mddb --security-opt label=disable welder/bdcs-api-rs:latest
+
+python ./tests/test_depsolve.py -v


### PR DESCRIPTION
Moved recipes depsolve tests here because `bdcs/depsolve` needs a list of NEVRA instead of recipe name.  For the moment the recipes here will have to be kept in sync with the examples in bdcs-api-rs because this is what currently provides the depsolving. Once bdcs-cli switches over to the depsolving code from the bdcs library this shouldn't be an issue anymore!
