### PR TITLE
Test related updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,43 +6,13 @@ services:
 
 cache:
   directories:
-    - ~/.ghc
-    - ~/.cabal
-
-before_install:
-  - sudo docker pull welder/bdcs-api-rs:latest
-  - sudo docker pull welder/bdcs-cli:latest
-  - sudo pip install s3cmd
-  - wget --progress=dot:giga https://haskell.org/platform/download/8.0.2/haskell-platform-8.0.2-unknown-posix--minimal-x86_64.tar.gz
-  - tar -xzvf ./haskell-platform-8.0.2-unknown-posix--minimal-x86_64.tar.gz
-  - sudo ./install-haskell-platform.sh
-  - travis_retry cabal update && cabal install hpc-coveralls
+    - .cabal-sandbox/
 
 script:
-  - |
-        set -e
-        API_CONTAINER_RUNNING=skip-check make test-in-docker
-
-        # copy the newly built files and coverage data out of
-        # the container
-        sudo docker create --name test-cont welder/bdcs-cli:latest /bin/bash
-        sudo docker cp test-cont:/bdcs-cli/dist ./dist
-        sudo docker rm test-cont
+  - API_CONTAINER_RUNNING=skip-check make ci
 
 after_success:
-  - |
-        sudo chown travis:travis -R ./dist
-        ~/.cabal/bin/hpc-coveralls --display-report spec bdcs-cli
-
-        if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-            sudo docker tag welder/bdcs-cli:latest welder/bdcs-cli:$TRAVIS_BUILD_NUMBER
-
-            docker login -u atodorov -p $DOCKER_PASSWORD
-            docker push welder/bdcs-cli
-
-            s3cmd sync --access_key="$ARTIFACTS_KEY" --secret_key="$ARTIFACTS_SECRET" \
-                        -v -P ./dist/build/bdcs-cli/bdcs-cli s3://weldr/bdcs-cli
-        fi
+  - make ci_after_success
 
 notifications:
   email:

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,35 +1,15 @@
-FROM fedora:26
+FROM fedora:27
 
 RUN dnf -y install python3-dnf-plugins-core && \
     dnf -y copr enable @weldr/bdcs-haskell-deps && \
     rpm --import https://copr-be.cloud.fedoraproject.org/results/@weldr/bdcs-haskell-deps/pubkey.gpg && \
-    dnf -y install sudo cabal-install cabal-rpm sqlite \
-                   python-toml python-nose-parameterized \
-                   gobject-introspection-devel ghc-*weldr* \
+    dnf -y install sudo cabal-install cabal-rpm sqlite python3-toml \
+                   https://kojipkgs.fedoraproject.org/packages/python-parameterized/0.6.1/2.fc28/noarch/python3-parameterized-0.6.1-2.fc28.noarch.rpm \
+                   gobject-introspection-devel \
                    ghc-haskell-gi-devel libgit2-glib-devel \
-                   hlint ostree beakerlib
+                   ostree beakerlib
 
-RUN mkdir /bdcs-cli
+# source is bind-mounted here
 WORKDIR /bdcs-cli
-
-# install the build dependencies first so we can cache this layer
-COPY BDCSCli.cabal .
-RUN cabal update
-RUN for i in `cabal install --dependencies-only --enable-tests --enable-coverage --dry-run | \
-              grep - | grep -v "In order" | grep -v basement | grep -v overloading | \
-              sed -r 's|-[0-9]+(\.[0-9]+)*||'`; do \
-        echo ghc-$i ghc-$i-devel; done | xargs dnf -y install && dnf clean all
-
-# copy the rest of the code
-COPY . /bdcs-cli
-
-# build the application
-RUN hlint .
-RUN cabal configure --enable-tests --enable-coverage --ghc-option=-DTEST && \
-    cabal build && \
-    cabal test --show-details=always
-
-# if all unit tests were successfull then create metadata.db
-RUN ./tests/bin/import-metadata
 
 ENTRYPOINT ["/bdcs-cli/entrypoint-integration-test.sh"]

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ default: all
 all: bdcs-cli
 
 sandbox:
-	[ -d .cabal-sandbox ] || cabal sandbox init
+	cabal update
+	cabal sandbox init
 
 bdcs-cli: sandbox
-	cabal update
 	cabal install --dependencies-only
 	cabal configure
 	cabal build
@@ -24,40 +24,43 @@ clean:
 hlint: sandbox
 	[ -x .cabal-sandbox/bin/happy ] || cabal install happy
 	[ -x .cabal-sandbox/bin/hlint ] || cabal install hlint
-	cabal exec hlint .
+	.cabal-sandbox/bin/hlint .
 
 tests: sandbox
+	# TODO: shouldn't we install dependencies from RPMs instead ?
 	cabal install --dependencies-only --enable-tests
-	cabal configure --enable-tests --enable-coverage
+	cabal configure --enable-tests --enable-coverage --ghc-option=-DTEST
 	cabal build
-	cabal test
+	cabal test --show-details=always
 	./tests/test_binary.sh
 
 test-in-docker: Dockerfile.build
 	sudo docker network inspect welder || sudo docker network create welder
 
-	# building the docker image executes all unit tests
-	if [ -n "$$TRAVIS" ]; then \
-	    sudo docker build -t $(ORG_NAME)/bdcs-cli:latest -f $< --cache-from $(ORG_NAME)/bdcs-cli:latest . ; \
-	else \
-	    sudo docker build -t $(ORG_NAME)/bdcs-cli:latest -f $< .; \
-	fi;
-
-	# copy metadata.db out of the container so we can pass it to
-	# the API container using the volume mount below!
-	sudo docker create --name metadata-cont $(ORG_NAME)/bdcs-cli /bin/bash
-	sudo docker cp metadata-cont:/bdcs-cli/metadata.db .
-	sudo docker rm metadata-cont
-
 	# run the API backend which provides depsolving
-	[ "$(API_CONTAINER_RUNNING)" == "1" ] || sudo docker run -d --rm --name api -p 4000:4000 -v `pwd`:/mddb --security-opt label=disable --network welder welder/bdcs-api-rs:latest
+	# metdata.db will be created after all unit tests pass
+	[ "$(API_CONTAINER_RUNNING)" == "1" ] || sudo docker run -d --name api -p 4000:4000 -v `pwd`:/mddb --security-opt label=disable --network welder welder/bdcs-api-rs:latest
 
-	# running the bdcs-cli image executes all integration tests
-	sudo docker run --name tests --network welder $(ORG_NAME)/bdcs-cli:latest
+	# building the docker image and execute the tests
+	sudo docker build -t $(ORG_NAME)/bdcs-cli:latest -f $< .
+	sudo docker run --rm --network welder --security-opt label=disable -v `pwd`:/bdcs-cli/ welder/bdcs-cli
 	sudo docker stop api
+	sudo docker rm api
 	sudo docker network remove welder
+
+
+ci: test-in-docker
 
 test-images:
 	./tests/test_images.sh
+
+ci_after_success:
+	sudo docker run --rm --security-opt label=disable -v `pwd`:/bdcs-cli/ \
+	        --env "TRAVIS=$$TRAVIS" --env "TRAVIS_JOB_ID=$$TRAVIS_JOB_ID" \
+	        --entrypoint /usr/bin/make welder/bdcs-cli coveralls
+
+coveralls: sandbox
+	[ -x .cabal-sandbox/bin/hpc-coveralls ] || cabal install hpc-coveralls
+	.cabal-sandbox/bin/hpc-coveralls --display-report test-bdcs bdcs
 
 .PHONY: sandbox bdcs-cli clean test hlint

--- a/entrypoint-integration-test.sh
+++ b/entrypoint-integration-test.sh
@@ -4,6 +4,13 @@ set -ex
 
 cd /bdcs-cli/
 
+# build the application
+make hlint tests
+
+# if all unit tests were successfull then create metadata.db
+./tests/bin/import-metadata
+
+
 # don't produce XML journal b/c that needs Python
 export BEAKERLIB_JOURNAL=0
 

--- a/examples/recipes/development.toml
+++ b/examples/recipes/development.toml
@@ -2,10 +2,6 @@ name = "development"
 description = "A general purpose development image"
 
 [[packages]]
-name = "cmake"
-version = "*"
-
-[[packages]]
 name = "curl"
 version = "*"
 

--- a/tests/bin/import-metadata
+++ b/tests/bin/import-metadata
@@ -30,6 +30,11 @@ DNF_DOWNLOAD=`mktemp -d /tmp/dnf.download.XXXXXX`
 ./tests/bin/recipes2rpms | xargs sudo dnf install -y --nogpgcheck --releasever=26 \
                                                      --downloadonly --downloaddir=$DNF_DOWNLOAD \
                                                      --installroot=$DNF_ROOT
+
+# download additional RPMs which are weak dependencies (e.g. Suggests:)
+sudo dnf install -y --nogpgcheck --releasever=26 --downloadonly --downloaddir=$DNF_DOWNLOAD \
+                    --installroot=$DNF_ROOT perl-Authen-SASL perl-Business-ISBN
+
 # then import all RPMs
 for F in $DNF_DOWNLOAD/*.rpm; do
     $IMPORT $METADATA $IMPORT_REPO file://$F

--- a/tests/bin/recipes2rpms
+++ b/tests/bin/recipes2rpms
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python3
 
 # parse the toml recipes and produce a list of RPMs suitable for
 # installation by dnf

--- a/tests/test_depsolve.sh
+++ b/tests/test_depsolve.sh
@@ -19,11 +19,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest
-        RUNNER="python"
-        if ! rlCheckRpm python-nose-parameterized; then
-            RUNNER="nosetests"
-        fi
-        rlRun "$RUNNER ./tests/test_depsolve.py -v"
+        rlRun "python3 ./tests/test_depsolve.py -v"
     rlPhaseEnd
 
 rlJournalEnd


### PR DESCRIPTION
Currently only depsolving for the development recipe fails. The API server responds with:

```
GET /api/v0/recipes/depsolve/development:
    => Matched: GET /api/v0/recipes/depsolve/<recipe_names>
Feb 23 11:00:19.497 INFO /recipes/depsolve/, recipe_names: development
Feb 23 11:00:19.498 DEBG depsolve_recipe, projs: ["cmake", "curl", "file", "gcc", "gcc-c++", "gdb", "git", "glibc-devel", "gnupg2", "libcurl-devel", "make", "openssl-devel", "sqlite", "sqlite-devel", "sudo", "tar", "xz", "xz-devel", "zlib-devel"]
Feb 23 11:00:19.501 ERRO close_dependencies, projects: ["cmake", "curl", "file", "gcc", "gcc-c++", "gdb", "git", "glibc-devel", "gnupg2", "libcurl-devel", "make", "openssl-devel", "sqlite", "sqlite-devel", "sudo", "tar", "xz", "xz-devel", "zlib-devel"], error: Unable to satisfy requirement (cmake = 3.10.1-11.fc26 if cmake < 3.10.1-11.fc26)
```

And into the database I have:

```
select * from builds where source_id = 17;
17|17|0|11.fc26|x86_64|2018-01-14T17:20:11|- rpm-macros: Keep cmake{,-data} in evr-lock, if they are installed|BUILD_CONFIG_REF|BUILD_ENV_REF
18|17|0|11.fc26|noarch|2018-01-14T17:20:11|- rpm-macros: Keep cmake{,-data} in evr-lock, if they are installed|BUILD_CONFIG_REF|BUILD_ENV_REF
```

The noarch version I think comes from cmake-data. 

Any ideas how to deal with that failure ?