### PR TITLE
Install bdcs.rpm from Copr instead of pulling it from S3

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,13 +1,13 @@
 FROM fedora:27
 
 RUN dnf -y install python3-dnf-plugins-core && \
-    dnf -y copr enable @weldr/bdcs-haskell-deps && \
-    rpm --import https://copr-be.cloud.fedoraproject.org/results/@weldr/bdcs-haskell-deps/pubkey.gpg && \
+    dnf -y copr enable @weldr/bdcs && \
+    rpm --import https://copr-be.cloud.fedoraproject.org/results/@weldr/bdcs/pubkey.gpg && \
     dnf -y install sudo cabal-install cabal-rpm sqlite python3-toml \
                    https://kojipkgs.fedoraproject.org/packages/python-parameterized/0.6.1/2.fc28/noarch/python3-parameterized-0.6.1-2.fc28.noarch.rpm \
                    gobject-introspection-devel \
                    ghc-haskell-gi-devel libgit2-glib-devel \
-                   ostree beakerlib
+                   ostree beakerlib bdcs
 
 # source is bind-mounted here
 WORKDIR /bdcs-cli

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -7,7 +7,7 @@ RUN dnf -y install python3-dnf-plugins-core && \
                    https://kojipkgs.fedoraproject.org/packages/python-parameterized/0.6.1/2.fc28/noarch/python3-parameterized-0.6.1-2.fc28.noarch.rpm \
                    gobject-introspection-devel \
                    ghc-haskell-gi-devel libgit2-glib-devel \
-                   ostree beakerlib bdcs
+                   ostree beakerlib bdcs libcurl-devel
 
 # source is bind-mounted here
 WORKDIR /bdcs-cli

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,9 @@ test-in-docker: Dockerfile.build
 
 ci: test-in-docker
 
-test-images:
+# this is executed on a Fedora 27 system in Jenkins
+# so first compile the binaries and then run image build tests
+test-images: bdcs-cli
 	./tests/test_images.sh
 
 ci_after_success:

--- a/tests/bin/import-metadata
+++ b/tests/bin/import-metadata
@@ -7,7 +7,8 @@ set -e
 # create the MDDB database if it doesn't exist
 # ARG1 - OPTIONAL - a content store directory for exports
 
-IMPORT="./bdcs-import"
+# needs bdcs.rpm installed
+IMPORT="/usr/libexec/weldr/bdcs-import"
 SCHEMA="./schema.sql"
 METADATA="metadata.db"
 
@@ -19,7 +20,6 @@ else
     REMOVE_IMPORT_REPO=0
 fi
 
-[ -f "$IMPORT" ] || curl -o "$IMPORT" https://s3.amazonaws.com/weldr/bdcs-import && chmod a+x "$IMPORT"
 [ -f "$SCHEMA" ] || curl -o "$SCHEMA" https://raw.githubusercontent.com/weldr/bdcs/master/schema.sql
 sqlite3 "$METADATA" < "$SCHEMA"
 
@@ -41,5 +41,5 @@ for F in $DNF_DOWNLOAD/*.rpm; do
 done
 
 # cleanup temporary directories and files
-rm -rf $DNF_ROOT $DNF_DOWNLOAD $IMPORT $SCHEMA || echo "Can't remove some files"
+rm -rf $DNF_ROOT $DNF_DOWNLOAD $SCHEMA || echo "Can't remove some files"
 [ "$REMOVE_IMPORT_REPO" == 1 ] && rm -rf $IMPORT_REPO || echo "Can't remove some files"

--- a/tests/test_images.sh
+++ b/tests/test_images.sh
@@ -7,17 +7,11 @@
 # exits on error but doesn't clean up
 set -e
 
-EXPORT="./bdcs-export"
-BDCS_CLI="./bdcs-cli"
+# needs bdcs.rpm installed
+BDCS_CLI="./dist/build/bdcs-cli/bdcs-cli"
 
 METADATA_DB="metadata.db"
 METADATA_REPO="cs.repo/"
-
-
-# download precompiled binaries if not available
-[ -f "./dist/build/bdcs-cli/bdcs-cli" ] && cp ./dist/build/bdcs-cli/bdcs-cli .
-[ -f "$BDCS_CLI" ] || curl -o "$BDCS_CLI" https://s3.amazonaws.com/weldr/bdcs-cli && chmod a+x "$BDCS_CLI"
-[ -f "$EXPORT" ] || curl -o "$EXPORT" https://s3.amazonaws.com/weldr/bdcs-export && chmod a+x "$EXPORT"
 
 
 # create the database if it doesn't exist


### PR DESCRIPTION
Note: the failure in test_images.sh is from the command:

```
./dist/build/bdcs-cli/bdcs-cli --url http://api:4000/ -m metadata.db -r metadata.repo/ compose tar http-server
Creating tar of http-server, saving to http-server.tar
bdcs-cli: export: rawSystem: runInteractiveProcess: exec: does not exist (No such file or directory)
```

which looks like it can't find bdcs-export.